### PR TITLE
Fix ImGui not working when Slate Global Invalidation is enabled

### DIFF
--- a/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
+++ b/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
@@ -112,6 +112,9 @@ void SImGuiWidget::Construct(const FArguments& InArgs)
 	// Initialize state.
 	UpdateVisibility();
 	UpdateMouseCursor();
+	
+	// Support Slate Global Invalidation.
+	ForceVolatile(true);
 
 	ChildSlot
 	[


### PR DESCRIPTION
With Imgui being immediate mode, it needs to re-render every frame but Slate Global Invalidation will only re-render widgets when they invalidate or if they are volatile, so this change makes the ImGui widget volatile.