### PR TITLE
Fix MetaClass warning for `UImGuiSettings::ImGuiInputHandlerClass`

### DIFF
--- a/Source/ImGui/Private/ImGuiModuleSettings.h
+++ b/Source/ImGui/Private/ImGuiModuleSettings.h
@@ -175,7 +175,7 @@ protected:
 
 	// Path to own implementation of ImGui Input Handler allowing to customize handling of keyboard and gamepad input.
 	// If not set then default handler is used.
-	UPROPERTY(EditAnywhere, config, Category = "Extensions", meta = (MetaClass = "ImGuiInputHandler"))
+	UPROPERTY(EditAnywhere, config, Category = "Extensions", meta = (MetaClass = "/Script/ImGui.ImGuiInputHandler"))
 	FSoftClassPath ImGuiInputHandlerClass;
 
 	// Whether ImGui should share keyboard input with game.


### PR DESCRIPTION
```
Wed Oct 25 17:24:39 PDT 2023  Warning      LogClass                  Property StructProperty UImGuiSettings::ImGuiInputHandlerClass defines MetaData key "MetaClass" which contains short type name "ImGuiInputHandler". Suggested pathname: "/Script/ImGui.ImGuiInputHandler". Module:ImGui File:Private/ImGuiModuleSettings.h
```