### PR TITLE
Fix DPIScale never getting initialized properly

### DIFF
--- a/Source/ImGui/Private/ImGuiModuleSettings.cpp
+++ b/Source/ImGui/Private/ImGuiModuleSettings.cpp
@@ -5,8 +5,7 @@
 #include "ImGuiModuleCommands.h"
 #include "ImGuiModuleProperties.h"
 
-#include <Engine/Engine.h>
-#include <GameFramework/GameUserSettings.h>
+#include <Framework/Application/SlateApplication.h>
 #include <Misc/ConfigCacheIni.h>
 
 
@@ -31,11 +30,20 @@ FImGuiDPIScaleInfo::FImGuiDPIScaleInfo()
 float FImGuiDPIScaleInfo::CalculateResolutionBasedScale() const
 {
 	float ResolutionBasedScale = 1.f;
-	if (bScaleWithCurve && GEngine && GEngine->GameUserSettings)
+	if (bScaleWithCurve)
 	{
 		if (const FRichCurve* Curve = DPICurve.GetRichCurveConst())
 		{
-			ResolutionBasedScale *= Curve->Eval((float)GEngine->GameUserSettings->GetDesktopResolution().Y, 1.f);
+			FDisplayMetrics DisplayMetrics;
+			DisplayMetrics.PrimaryDisplayWidth = 0;
+			DisplayMetrics.PrimaryDisplayHeight = 0;
+
+			if (FSlateApplication::IsInitialized())
+			{
+				FSlateApplication::Get().GetInitialDisplayMetrics(DisplayMetrics);
+			}
+
+			ResolutionBasedScale *= Curve->Eval((float)DisplayMetrics.PrimaryDisplayHeight, 1.f);
 		}
 	}
 	return ResolutionBasedScale;


### PR DESCRIPTION
Problem & Repro steps are:

- Launch the editor with a 4k monitor
- Launch a PIE session with the plugin enabled, and with the default settings
- Bring up the imgui demo window, notice that it's tiny
- Open the UnrealImgui Project Settings page, and dirty the DPICurve, observe that the demo window doubles in size.

GEngine is invalid at this point because the plugin is set to the PreDefault loading phase, and the callstack to get into CalculateResolutionBasedScale runs via module load. We had tried changing the LoadingPhase which also fixed it but resulted in other issues.

This code is just taken from the call to GetDesktopResolution(), that function does a little more to fallback if SlateApplication is not initialized, but that doesn't seem to be necessary here.