### PR TITLE
Use ImDrawCmd::IdxOffset for advancing offset of index buffer

### DIFF
--- a/Source/ImGui/Private/ImGuiDrawData.h
+++ b/Source/ImGui/Private/ImGuiDrawData.h
@@ -14,6 +14,7 @@
 struct FImGuiDrawCommand
 {
 	uint32 NumElements;
+	uint32 IndexOffset;
 	FSlateRect ClippingRect;
 	TextureIndex TextureId;
 };
@@ -33,7 +34,7 @@ public:
 	FImGuiDrawCommand GetCommand(int CommandNb, const FTransform2D& Transform) const
 	{
 		const ImDrawCmd& ImGuiCommand = ImGuiCommandBuffer[CommandNb];
-		return { ImGuiCommand.ElemCount, TransformRect(Transform, ImGuiInterops::ToSlateRect(ImGuiCommand.ClipRect)),
+		return { ImGuiCommand.ElemCount, ImGuiCommand.IdxOffset, TransformRect(Transform, ImGuiInterops::ToSlateRect(ImGuiCommand.ClipRect)),
 			ImGuiInterops::ToTextureIndex(ImGuiCommand.TextureId) };
 	}
 

--- a/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
+++ b/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
@@ -654,15 +654,11 @@ int32 SImGuiWidget::OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeo
 			DrawList.CopyVertexData(VertexBuffer, ImGuiToScreen);
 #endif // ENGINE_COMPATIBILITY_LEGACY_CLIPPING_API
 
-			int IndexBufferOffset = 0;
 			for (int CommandNb = 0; CommandNb < DrawList.NumCommands(); CommandNb++)
 			{
 				const auto& DrawCommand = DrawList.GetCommand(CommandNb, ImGuiToScreen);
 
-				DrawList.CopyIndexData(IndexBuffer, IndexBufferOffset, DrawCommand.NumElements);
-
-				// Advance offset by number of copied elements to position it for the next command.
-				IndexBufferOffset += DrawCommand.NumElements;
+				DrawList.CopyIndexData(IndexBuffer, DrawCommand.IndexOffset, DrawCommand.NumElements);
 
 				// Get texture resource handle for this draw command (null index will be also mapped to a valid texture).
 				const FSlateResourceHandle& Handle = ModuleManager->GetTextureManager().GetTextureHandle(DrawCommand.TextureId);


### PR DESCRIPTION
This pull request fixes incorrect background color of popup modal by taking `ImDrawCmd::IdxOffset` into consideration in Slate widget for rendering ImGui output.

Please refer to the following pages for the problem and fix that are almost identical to this PR.  Thanks.

* https://github.com/ocornut/imgui/issues/4845
* https://github.com/ocornut/imgui/commit/c80e8b964cbb75c4202949ad86f4b0bb3ea6aa44
