### PR TITLE
Add `ToggleInput` keybinding support for all `UPlayerInput` based systems (including EnhancedInput & custom)

### DIFF
--- a/Source/ImGui/Private/ImGuiModuleSettings.cpp
+++ b/Source/ImGui/Private/ImGuiModuleSettings.cpp
@@ -88,9 +88,13 @@ FImGuiModuleSettings::FImGuiModuleSettings(FImGuiModuleProperties& InProperties,
 {
 #if WITH_EDITOR
 	FCoreUObjectDelegates::OnObjectPropertyChanged.AddRaw(this, &FImGuiModuleSettings::OnPropertyChanged);
+
 	// Force key bindings to be registered again once the editor initialization is completed
 	// So that if there were any input types missed due to loading order, we can inject settings into them as well
-	EditorInitDelegateHandle = FEditorDelegates::OnEditorInitialized.AddLambda([this](double Duration){ Commands.SetKeyBinding(FImGuiModuleCommands::ToggleInput, ToggleInputKey); });
+	EditorInitDelegateHandle = FEditorDelegates::OnEditorInitialized.AddLambda([this](double Duration)
+	{
+		Commands.SetKeyBinding(FImGuiModuleCommands::ToggleInput, ToggleInputKey);
+	});
 #endif
 
 	// Delegate initializer to support settings loaded after this object creation (in stand-alone builds) and potential

--- a/Source/ImGui/Private/ImGuiModuleSettings.cpp
+++ b/Source/ImGui/Private/ImGuiModuleSettings.cpp
@@ -80,6 +80,9 @@ FImGuiModuleSettings::FImGuiModuleSettings(FImGuiModuleProperties& InProperties,
 {
 #if WITH_EDITOR
 	FCoreUObjectDelegates::OnObjectPropertyChanged.AddRaw(this, &FImGuiModuleSettings::OnPropertyChanged);
+	// Force key bindings to be registered again once the editor initialization is completed
+	// So that if there were any input types missed due to loading order, we can inject settings into them as well
+	EditorInitDelegateHandle = FEditorDelegates::OnEditorInitialized.AddLambda([this](double Duration){ Commands.SetKeyBinding(FImGuiModuleCommands::ToggleInput, ToggleInputKey); });
 #endif
 
 	// Delegate initializer to support settings loaded after this object creation (in stand-alone builds) and potential
@@ -97,6 +100,7 @@ FImGuiModuleSettings::~FImGuiModuleSettings()
 
 #if WITH_EDITOR
 	FCoreUObjectDelegates::OnObjectPropertyChanged.RemoveAll(this);
+	FEditorDelegates::OnEditorInitialized.Remove(EditorInitDelegateHandle);
 #endif
 }
 

--- a/Source/ImGui/Private/ImGuiModuleSettings.h
+++ b/Source/ImGui/Private/ImGuiModuleSettings.h
@@ -296,6 +296,8 @@ private:
 
 #if WITH_EDITOR
 	void OnPropertyChanged(class UObject* ObjectBeingModified, struct FPropertyChangedEvent& PropertyChangedEvent);
+
+	FDelegateHandle EditorInitDelegateHandle;
 #endif // WITH_EDITOR
 
 	FImGuiModuleProperties& Properties;

--- a/Source/ImGui/Private/Utilities/DebugExecBindings.cpp
+++ b/Source/ImGui/Private/Utilities/DebugExecBindings.cpp
@@ -86,12 +86,12 @@ namespace DebugExecBindings
 		const FKeyBind KeyBind = CreateKeyBind(KeyInfo, Command);
 
 		// Update all possible default player inputs, so changes will be visible in all PIE sessions created after this point.
-		for (TObjectIterator<UClass> It; It; ++It)
+		TArray<UClass*> InputClasses;
+		GetDerivedClasses(UPlayerInput::StaticClass(), InputClasses, true);
+		InputClasses.Add(UPlayerInput::StaticClass());
+		for (const UClass* InputClass : InputClasses)
 		{
-			if (It->IsChildOf(UPlayerInput::StaticClass()))
-			{
-				UpdatePlayerInput(Cast<UPlayerInput>(It->GetDefaultObject()), KeyBind);
-			}
+			UpdatePlayerInput(Cast<UPlayerInput>(InputClass->GetDefaultObject()), KeyBind);
 		}
 
 		// Update all existing player inputs to see changes in running PIE session.

--- a/Source/ImGui/Private/Utilities/DebugExecBindings.cpp
+++ b/Source/ImGui/Private/Utilities/DebugExecBindings.cpp
@@ -85,10 +85,13 @@ namespace DebugExecBindings
 
 		const FKeyBind KeyBind = CreateKeyBind(KeyInfo, Command);
 
-		// Update default player input, so changes will be visible in all PIE sessions created after this point.
-		if (UPlayerInput* DefaultPlayerInput = GetMutableDefault<UPlayerInput>())
+		// Update all possible default player inputs, so changes will be visible in all PIE sessions created after this point.
+		for (TObjectIterator<UClass> It; It; ++It)
 		{
-			UpdatePlayerInput(DefaultPlayerInput, KeyBind);
+			if (It->IsChildOf(UPlayerInput::StaticClass()))
+			{
+				UpdatePlayerInput(Cast<UPlayerInput>(It->GetDefaultObject()), KeyBind);
+			}
 		}
 
 		// Update all existing player inputs to see changes in running PIE session.


### PR DESCRIPTION
With the engine's recent change to defaulting to EnhancedInput, UnrealImGui's ToggleInput keybinding doesn't properly register itself during initialization and requires itself to be reconfigured while in PIE; see: <https://github.com/IDI-Systems/UnrealImGui/issues/13>

This change aims to fix this in 2 steps;
    - Instead of getting the default object for the specific input type, scan all the classes that extends it and register the binding with all of them
    - Force this operation again once the editor initialization is completed, as due to nature of the module loading in the editor it's possible, not all input types are registered by the time UnrealImGui is initialized which results in the first pass missing some input types (this happens if the project has implemented their own input class extending UPlayerInput or UEnhancedPlayerInput)