### PR TITLE
Fix modifier keys being reset by UpdateKeyboardInputs called by NewFrame

### DIFF
--- a/Source/ImGui/Private/ImGuiInteroperability.cpp
+++ b/Source/ImGui/Private/ImGuiInteroperability.cpp
@@ -360,11 +360,11 @@ namespace ImGuiInterops
 		static const uint32 LeftAlt = GetKeyIndex(EKeys::LeftAlt);
 		static const uint32 RightAlt = GetKeyIndex(EKeys::RightAlt);
 
-		// Copy key modifiers.
-		IO.KeyCtrl = InputState.IsControlDown();
-		IO.KeyShift = InputState.IsShiftDown();
-		IO.KeyAlt = InputState.IsAltDown();
-		IO.KeySuper = false;
+		// Update modifier key events
+		IO.AddKeyEvent(ImGuiKey_ModShift, InputState.IsShiftDown());
+		IO.AddKeyEvent(ImGuiKey_ModCtrl, InputState.IsControlDown());
+		IO.AddKeyEvent(ImGuiKey_ModAlt, InputState.IsAltDown());
+		IO.AddKeyEvent(ImGuiKey_ModSuper, false);
 
 		// Copy buffers.
 		if (!InputState.GetKeysUpdateRange().IsEmpty())

--- a/Source/ImGui/Private/ImGuiInteroperability.cpp
+++ b/Source/ImGui/Private/ImGuiInteroperability.cpp
@@ -361,8 +361,8 @@ namespace ImGuiInterops
 		static const uint32 RightAlt = GetKeyIndex(EKeys::RightAlt);
 
 		// Update modifier key events
-		IO.AddKeyEvent(ImGuiKey_ModShift, InputState.IsShiftDown());
 		IO.AddKeyEvent(ImGuiKey_ModCtrl, InputState.IsControlDown());
+		IO.AddKeyEvent(ImGuiKey_ModShift, InputState.IsShiftDown());
 		IO.AddKeyEvent(ImGuiKey_ModAlt, InputState.IsAltDown());
 		IO.AddKeyEvent(ImGuiKey_ModSuper, false);
 


### PR DESCRIPTION
Previously IO.KeyCtrl, KeyShift, KeyAlt, KeySuper was being manually set before NewFrame started. Those values were being reset when NewFrame is called as that calls UpdateKeyboardInputs() which checks if mod keys are down. As we were never adding events for Mod keys it was resetting it back to false.

This PR will properly update events for Mod Keys that imgui uses for various purposes.