### PR TITLE
Fix assert on shutdown

### DIFF
--- a/Source/ImGui/Private/ImGuiContextManager.cpp
+++ b/Source/ImGui/Private/ImGuiContextManager.cpp
@@ -78,6 +78,9 @@ FImGuiContextManager::FImGuiContextManager(FImGuiModuleSettings& InSettings)
 
 FImGuiContextManager::~FImGuiContextManager()
 {
+	// Early dealloc of contexts for clean shutdown order
+	Contexts.Reset();
+
 	Settings.OnDPIScaleChangedDelegate.RemoveAll(this);
 
 	// Order matters because contexts can be created during World Tick Start events.

--- a/Source/ImGui/Private/ImGuiContextProxy.cpp
+++ b/Source/ImGui/Private/ImGuiContextProxy.cpp
@@ -119,6 +119,9 @@ FImGuiContextProxy::~FImGuiContextProxy()
 		// version), even though we can pass it to the destroy function.
 		SetAsCurrent();
 
+		// Ensure frame has ended
+		EndFrame();
+
 		// Save context data and destroy.
 		ImGui::DestroyContext(Context);
 


### PR DESCRIPTION
This has been an issue in the original @segross version already - enabling IM_ASSERT will flag an assert on shutdown because 1. it tries to destroy the module before clearing out the contexts, and 2. because the context proxy tick works on an "end frame first, begin new immediately" logic, there's never a final end frame before destruction.