### PR TITLE
Add helper functions to retrieve texture object from handle or name

### DIFF
--- a/Source/ImGui/Private/ImGuiModule.cpp
+++ b/Source/ImGui/Private/ImGuiModule.cpp
@@ -84,6 +84,18 @@ FImGuiTextureHandle FImGuiModule::FindTextureHandle(const FName& Name)
 	return (Index != INDEX_NONE) ? FImGuiTextureHandle{ Name, ImGuiInterops::ToImTextureID(Index) } : FImGuiTextureHandle{};
 }
 
+UTexture* FImGuiModule::FindTexture(const FName& Name)
+{
+	const TextureIndex Index = ImGuiModuleManager->GetTextureManager().FindTextureIndex(Name);
+	return (Index != INDEX_NONE) ? ImGuiModuleManager->GetTextureManager().GetTextureObject(Index) : nullptr;
+}
+
+UTexture* FImGuiModule::FindTexture(const FImGuiTextureHandle& Handle)
+{
+	const TextureIndex Index = ImGuiInterops::ToTextureIndex(Handle.GetTextureId());
+	return (Index != INDEX_NONE) ? ImGuiModuleManager->GetTextureManager().GetTextureObject(Index) : nullptr;
+}
+
 FImGuiTextureHandle FImGuiModule::RegisterTexture(const FName& Name, class UTexture* Texture, bool bMakeUnique)
 {
 	FTextureManager& TextureManager = ImGuiModuleManager->GetTextureManager();

--- a/Source/ImGui/Private/TextureManager.h
+++ b/Source/ImGui/Private/TextureManager.h
@@ -62,6 +62,16 @@ public:
 		return IsValidTexture(Index) ? TextureResources[Index].GetResourceHandle() : ErrorTexture.GetResourceHandle();
 	}
 
+	// Get the texture object to a texture at given index. If index is out of range or resources are not valid
+	// it returns nullptr.
+	// @param Index - Index of a texture
+	// @returns The texture object for a texture at given index or nullptr, if no valid resources were
+	// found at given index
+	UTexture* GetTextureObject(TextureIndex Index) const
+	{
+		return IsValidTexture(Index) ? TextureResources[Index].GetTexture() : nullptr;
+	}
+
 	// Create a texture from raw data.
 	// @param Name - The texture name
 	// @param Width - The texture width
@@ -139,6 +149,7 @@ private:
 
 		const FName& GetName() const { return Name; }
 		const FSlateResourceHandle& GetResourceHandle() const;
+		UTexture* GetTexture() const { return Cast<UTexture>(Brush.GetResourceObject()); }
 
 	private:
 

--- a/Source/ImGui/Public/ImGuiModule.h
+++ b/Source/ImGui/Public/ImGuiModule.h
@@ -94,6 +94,22 @@ public:
 	virtual FImGuiTextureHandle FindTextureHandle(const FName& Name);
 
 	/**
+	 * If it exists, get a texture object with given resource name.
+	 *
+	 * @param Name - Resource name of a texture to find
+	 * @returns The texture object, or nullptr if not found
+	 */
+	virtual UTexture* FindTexture(const FName& Name);
+
+	/**
+	 * If it exists, get a texture object with given texture handle.
+	 *
+	 * @param Name - Resource name of a texture to find
+	 * @returns The texture object, or nullptr if not found
+	 */
+	virtual UTexture* FindTexture(const FImGuiTextureHandle& Handle);
+
+	/**
 	 * Register texture and create its Slate resources. If texture with that name already exists then it may be updated
 	 * or if bMakeUnique is true, exception will be thrown. Throws exception, if name argument is NAME_None or texture
 	 * is null.


### PR DESCRIPTION
This is handy when a situation calls for you to have a texture object (for e.g. pulling out the dimensions to get an aspect ratio) but you only have the texture handle at hand.

(e.g. `UTexture * tex = FImGuiModule::Get().FindTexture(texHandle);`)