### PR TITLE
Fix an issue when using both "ImGui" and "Common UI" plugins where "accept" button presses are consumed by the "CommonAnalogCursor" preprocessor.

### DIFF
--- a/Source/ImGui/Private/ImGuiInputHandlerFactory.cpp
+++ b/Source/ImGui/Private/ImGuiInputHandlerFactory.cpp
@@ -9,7 +9,7 @@
 #include <InputCoreTypes.h>
 
 
-UImGuiInputHandler* FImGuiInputHandlerFactory::NewHandler(const FSoftClassPath& HandlerClassReference, FImGuiModuleManager* ModuleManager, UGameViewportClient* GameViewport, int32 ContextIndex)
+UImGuiInputHandler* FImGuiInputHandlerFactory::NewHandler(const FSoftClassPath& HandlerClassReference, FImGuiModuleManager* ModuleManager, UGameViewportClient* GameViewport, int32 ContextIndex, TSharedRef<SImGuiWidget> Widget)
 {
 	UClass* HandlerClass = nullptr;
 	if (HandlerClassReference.IsValid())
@@ -30,7 +30,7 @@ UImGuiInputHandler* FImGuiInputHandlerFactory::NewHandler(const FSoftClassPath& 
 	UImGuiInputHandler* Handler = NewObject<UImGuiInputHandler>(GameViewport, HandlerClass);
 	if (Handler)
 	{
-		Handler->Initialize(ModuleManager, GameViewport, ContextIndex);
+		Handler->Initialize(ModuleManager, GameViewport, ContextIndex, Widget);
 		Handler->AddToRoot();
 	}
 	else
@@ -45,6 +45,7 @@ void FImGuiInputHandlerFactory::ReleaseHandler(UImGuiInputHandler* Handler)
 {
 	if (Handler)
 	{
+		Handler->Deinitialize();
 		Handler->RemoveFromRoot();
 	}
 }

--- a/Source/ImGui/Private/ImGuiInputHandlerFactory.h
+++ b/Source/ImGui/Private/ImGuiInputHandlerFactory.h
@@ -13,7 +13,7 @@ class FImGuiInputHandlerFactory
 {
 public:
 
-	static UImGuiInputHandler* NewHandler(const FSoftClassPath& HandlerClassReference, FImGuiModuleManager* ModuleManager, UGameViewportClient* GameViewport, int32 ContextIndex);
+	static UImGuiInputHandler* NewHandler(const FSoftClassPath& HandlerClassReference, FImGuiModuleManager* ModuleManager, UGameViewportClient* GameViewport, int32 ContextIndex, TSharedRef<class SImGuiWidget> Widget);
 
 	static void ReleaseHandler(UImGuiInputHandler* Handler);
 };

--- a/Source/ImGui/Private/ImGuiModuleSettings.cpp
+++ b/Source/ImGui/Private/ImGuiModuleSettings.cpp
@@ -123,6 +123,7 @@ void FImGuiModuleSettings::UpdateSettings()
 		SetShareGamepadInput(SettingsObject->bShareGamepadInput);
 		SetShareMouseInput(SettingsObject->bShareMouseInput);
 		SetUseSoftwareCursor(SettingsObject->bUseSoftwareCursor);
+		SetInputProcessorPriority(SettingsObject->InputProcessorPriority);
 		SetToggleInputKey(SettingsObject->ToggleInput);
 		SetCanvasSizeInfo(SettingsObject->CanvasSize);
 	}
@@ -179,6 +180,11 @@ void FImGuiModuleSettings::SetUseSoftwareCursor(bool bUse)
 		bUseSoftwareCursor = bUse;
 		OnUseSoftwareCursorChanged.Broadcast(bUse);
 	}
+}
+
+void FImGuiModuleSettings::SetInputProcessorPriority(int32 Priority)
+{
+	InputProcessorPriority = Priority;
 }
 
 void FImGuiModuleSettings::SetToggleInputKey(const FImGuiKeyInfo& KeyInfo)

--- a/Source/ImGui/Private/ImGuiModuleSettings.h
+++ b/Source/ImGui/Private/ImGuiModuleSettings.h
@@ -202,6 +202,14 @@ protected:
 	UPROPERTY(EditAnywhere, config, Category = "Input", AdvancedDisplay)
 	bool bUseSoftwareCursor = false;
 
+	// The input processor priority when registering.
+	// This is used to fix an issue where the CommonAnalogCursor preprocessor would consume "accept" button presses on controller.
+	// An earlier priority means it will receive input earlier and other processors won't be able to block it from receiving
+	// events. A later priority means it won't block other processors when inputs are pressed. The priority needs to have a value
+	// that balances between these 2 scenarios. -1 means the input processor will be added to the end of the input processor list.
+	UPROPERTY(EditAnywhere, config, Category = "Input", AdvancedDisplay)
+	int32 InputProcessorPriority = 2;
+
 	// Define a shortcut key to 'ImGui.ToggleInput' command. Binding is only set if the key field is valid.
 	// Note that modifier key properties can be set to one of the three values: undetermined means that state of the given
 	// modifier is not important, checked means that it needs to be pressed and unchecked means that it cannot be pressed.
@@ -258,6 +266,8 @@ public:
 	// Get the software cursor configuration.
 	bool UseSoftwareCursor() const { return bUseSoftwareCursor; }
 
+	int32 GetInputProcessorPriority() const { return InputProcessorPriority; }
+
 	// Get the shortcut configuration for 'ImGui.ToggleInput' command.
 	const FImGuiKeyInfo& GetToggleInputKey() const { return ToggleInputKey; }
 
@@ -290,6 +300,7 @@ private:
 	void SetShareGamepadInput(bool bShare);
 	void SetShareMouseInput(bool bShare);
 	void SetUseSoftwareCursor(bool bUse);
+	void SetInputProcessorPriority(int32 Priority);
 	void SetToggleInputKey(const FImGuiKeyInfo& KeyInfo);
 	void SetCanvasSizeInfo(const FImGuiCanvasSizeInfo& CanvasSizeInfo);
 	void SetDPIScaleInfo(const FImGuiDPIScaleInfo& ScaleInfo);
@@ -309,4 +320,5 @@ private:
 	bool bShareGamepadInput = false;
 	bool bShareMouseInput = false;
 	bool bUseSoftwareCursor = false;
+	int32 InputProcessorPriority = 2;
 };

--- a/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
+++ b/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
@@ -160,16 +160,24 @@ FReply SImGuiWidget::OnKeyChar(const FGeometry& MyGeometry, const FCharacterEven
 	return InputHandler->OnKeyChar(CharacterEvent);
 }
 
-FReply SImGuiWidget::OnKeyDown(const FGeometry& MyGeometry, const FKeyEvent& KeyEvent)
+FReply SImGuiWidget::OnKeyDown_Indirect(const FKeyEvent& KeyEvent)
 {
-	UpdateCanvasControlMode(KeyEvent);
-	return InputHandler->OnKeyDown(KeyEvent);
+	if (HasKeyboardFocus())
+	{
+		UpdateCanvasControlMode(KeyEvent);
+		return InputHandler->OnKeyDown(KeyEvent);
+	}
+	return FReply::Unhandled();
 }
 
-FReply SImGuiWidget::OnKeyUp(const FGeometry& MyGeometry, const FKeyEvent& KeyEvent)
+FReply SImGuiWidget::OnKeyUp_Indirect(const FKeyEvent& KeyEvent)
 {
-	UpdateCanvasControlMode(KeyEvent);
-	return InputHandler->OnKeyUp(KeyEvent);
+	if (HasKeyboardFocus())
+	{
+		UpdateCanvasControlMode(KeyEvent);
+		return InputHandler->OnKeyUp(KeyEvent);
+	}
+	return FReply::Unhandled();
 }
 
 FReply SImGuiWidget::OnAnalogValueChanged(const FGeometry& MyGeometry, const FAnalogInputEvent& AnalogInputEvent)
@@ -284,7 +292,7 @@ void SImGuiWidget::CreateInputHandler(const FSoftClassPath& HandlerClassReferenc
 
 	if (!InputHandler.IsValid())
 	{
-		InputHandler = FImGuiInputHandlerFactory::NewHandler(HandlerClassReference, ModuleManager, GameViewport.Get(), ContextIndex);
+		InputHandler = FImGuiInputHandlerFactory::NewHandler(HandlerClassReference, ModuleManager, GameViewport.Get(), ContextIndex, SharedThis(this));
 	}
 }
 

--- a/Source/ImGui/Private/Widgets/SImGuiWidget.h
+++ b/Source/ImGui/Private/Widgets/SImGuiWidget.h
@@ -52,9 +52,9 @@ public:
 
 	virtual FReply OnKeyChar(const FGeometry& MyGeometry, const FCharacterEvent& CharacterEvent) override;
 
-	virtual FReply OnKeyDown(const FGeometry& MyGeometry, const FKeyEvent& KeyEvent) override;
+	virtual FReply OnKeyDown_Indirect(const FKeyEvent& KeyEvent);
 
-	virtual FReply OnKeyUp(const FGeometry& MyGeometry, const FKeyEvent& KeyEvent) override;
+	virtual FReply OnKeyUp_Indirect(const FKeyEvent& KeyEvent);
 
 	virtual FReply OnAnalogValueChanged(const FGeometry& MyGeometry, const FAnalogInputEvent& AnalogInputEvent) override;
 

--- a/Source/ImGui/Public/ImGuiInputHandler.h
+++ b/Source/ImGui/Public/ImGuiInputHandler.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <CoreMinimal.h>
+#include <Framework/Application/IInputProcessor.h>
 #include <Input/Reply.h>
 #include <UObject/Object.h>
 #include <UObject/WeakObjectPtr.h>
@@ -174,9 +175,9 @@ private:
 
 	void OnPostImGuiUpdate();
 
-	void Initialize(FImGuiModuleManager* InModuleManager, UGameViewportClient* InGameViewport, int32 InContextIndex);
+	void Initialize(FImGuiModuleManager* InModuleManager, UGameViewportClient* InGameViewport, int32 InContextIndex, TSharedRef<class SImGuiWidget> Widget);
 
-	virtual void BeginDestroy() override;
+	void Deinitialize();
 
 	class FImGuiInputState* InputState = nullptr;
 
@@ -188,6 +189,8 @@ private:
 
 	TWeakObjectPtr<UGameViewportClient> GameViewport;
 
+	TSharedPtr<class FImGuiInputProcessor> InputProcessor;
+
 	int32 ContextIndex = -1;
 
 #if WITH_EDITOR
@@ -196,3 +199,16 @@ private:
 
 	friend class FImGuiInputHandlerFactory;
 };
+
+class FImGuiInputProcessor : public IInputProcessor
+{
+public:
+	FImGuiInputProcessor(TSharedRef<class SImGuiWidget> InOwnerWidget);
+	void Tick(const float DeltaTime, FSlateApplication& SlateApp, TSharedRef<ICursor> Cursor) override {};
+	bool HandleKeyDownEvent(FSlateApplication& SlateApp, const FKeyEvent& InKeyEvent) override;
+	bool HandleKeyUpEvent(FSlateApplication& SlateApp, const FKeyEvent& InKeyEvent) override;
+
+private:
+	TWeakPtr<class SImGuiWidget> OwnerWidget;
+};
+


### PR DESCRIPTION
At Surgent Studios we've been using both **ImGui** and **Common UI** but we've run into the above issue.

It can be fixed by adding an input preprocessor to ImGui that listens to inputs before **CommonAnalogCursor** has a chance to consume the button.