### PR TITLE
Added a few includes, forward declaration, and moved  GetTexture()

### DIFF
--- a/Source/ImGui/Private/TextureManager.cpp
+++ b/Source/ImGui/Private/TextureManager.cpp
@@ -6,6 +6,7 @@
 #include <Framework/Application/SlateApplication.h>
 
 #include <algorithm>
+#include "RHITypes.h"
 
 
 void FTextureManager::InitializeErrorTexture(const FColor& Color)
@@ -158,6 +159,11 @@ const FSlateResourceHandle& FTextureManager::FTextureEntry::GetResourceHandle() 
 		CachedResourceHandle = FSlateApplication::Get().GetRenderer()->GetResourceHandle(Brush);
 	}
 	return CachedResourceHandle;
+}
+
+UTexture* FTextureManager::FTextureEntry::GetTexture() const
+{
+	return Cast<UTexture>(Brush.GetResourceObject());
 }
 
 void FTextureManager::FTextureEntry::Reset(bool bReleaseResources)

--- a/Source/ImGui/Private/TextureManager.h
+++ b/Source/ImGui/Private/TextureManager.h
@@ -149,7 +149,7 @@ private:
 
 		const FName& GetName() const { return Name; }
 		const FSlateResourceHandle& GetResourceHandle() const;
-		UTexture* GetTexture() const { return Cast<UTexture>(Brush.GetResourceObject()); }
+		UTexture* GetTexture() const;
 
 	private:
 

--- a/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
+++ b/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
@@ -11,6 +11,7 @@
 #include "ImGuiModuleManager.h"
 #include "ImGuiModuleSettings.h"
 #include "TextureManager.h"
+#include "UnrealClient.h"
 #include "Utilities/Arrays.h"
 #include "VersionCompatibility.h"
 

--- a/Source/ImGui/Public/ImGuiModule.h
+++ b/Source/ImGui/Public/ImGuiModule.h
@@ -8,6 +8,7 @@
 
 #include <Modules/ModuleManager.h>
 
+class UTexture;
 
 class FImGuiModule : public IModuleInterface
 {


### PR DESCRIPTION
this allows successful compilation when the entire module isn't blobbed together, including when bAdaptiveUnityDisablesOptimizations is enabled in %appdata%\Unreal Engine\UnrealBuildTool\BuildConfiguration.xml