### PR TITLE
Fixed compilation for UE below 5.2

### DIFF
--- a/Source/ImGui/Private/TextureManager.cpp
+++ b/Source/ImGui/Private/TextureManager.cpp
@@ -6,7 +6,12 @@
 #include <Framework/Application/SlateApplication.h>
 
 #include <algorithm>
+#include "Misc/EngineVersionComparison.h"
+#if UE_VERSION_OLDER_THAN(5, 2, 0)
+#include "RHI.h"
+#else
 #include "RHITypes.h"
+#endif
 
 
 void FTextureManager::InitializeErrorTexture(const FColor& Color)


### PR DESCRIPTION
FUpdateTextureRegion2D moved from RHI.h to RHITypes.h in 5.2, my last changes broke compilation for UE below that

Fix tested with 4.27.2 / 5.1.1 / 5.2.1 / 5.4.4: 

- created project from FPS Template (C++, no extra content) from the UI
- compile/run once without plugin
- check the lack of ImGui.* commands in the console or imgui in the plugin window
- exit UE/VS
- copy the entire (patched) repository content in <Project Folder>/Plugins/UnrealImGui 
- regenerate solution, compile/run from visual studio
- Ensure imgui module appears in build log, then in UE plugin window
- Run game, check with console command ImGui.ToggleDemo

Cheers

